### PR TITLE
PILOT-1385 Copy emails directory into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN poetry install --no-dev --no-root --no-interaction
 
 FROM production-environment AS notification-image
 COPY app ./app
+COPY emails ./emails
 ENTRYPOINT ["python3", "-m", "app"]
 
 FROM production-environment AS development-environment

--- a/app/routers/v1/api_email/utils.py
+++ b/app/routers/v1/api_email/utils.py
@@ -50,7 +50,7 @@ def validate_email_content(text, template, template_kwargs):
             template = templates.get_template(template)
             new_text = template.render(template_kwargs)
         except jinja2.exceptions.TemplateNotFound:
-            result = 'Template not found'
+            result = f'Template not found: {template}'
             code = EAPIResponseCode.not_found
     return code, result, new_text
 


### PR DESCRIPTION
## Summary

- Fix: `emails` directory was not being copied into the production image, so no email templates could be accessed.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1385

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

Wait for deployment and see if it fixes the email send issue.
